### PR TITLE
TOB-7 fix

### DIFF
--- a/packages/portal-contracts/contracts/fuelchain/types/FuelBlockHeader.sol
+++ b/packages/portal-contracts/contracts/fuelchain/types/FuelBlockHeader.sol
@@ -12,7 +12,7 @@ struct FuelBlockHeader {
     // Merkle root of all previous consensus header hashes (not including this block)
     bytes32 prevRoot;
     // Height of this block
-    uint64 height;
+    uint32 height;
     // Time this block was created, in TAI64 format
     uint64 timestamp;
     /////////////////
@@ -62,13 +62,7 @@ library FuelBlockHeaderLib {
     /// @param header The block header structure.
     /// @return The serialized block consensus header.
     function serializeConsensusHeader(FuelBlockHeader memory header) internal pure returns (bytes memory) {
-        return
-            abi.encodePacked(
-                header.prevRoot,
-                (uint32)(header.height),
-                header.timestamp,
-                computeApplicationHeaderHash(header)
-            );
+        return abi.encodePacked(header.prevRoot, header.height, header.timestamp, computeApplicationHeaderHash(header));
     }
 
     /// @notice Produce the block consensus header hash.

--- a/packages/portal-contracts/contracts/fuelchain/types/FuelBlockHeaderLite.sol
+++ b/packages/portal-contracts/contracts/fuelchain/types/FuelBlockHeaderLite.sol
@@ -9,7 +9,7 @@ struct FuelBlockHeaderLite {
     // Merkle root of all previous consensus header hashes (not including this block)
     bytes32 prevRoot;
     // Height of this block
-    uint64 height;
+    uint32 height;
     // Time this block was created, in TAI64 format
     uint64 timestamp;
     // Hash of serialized application header for this block


### PR DESCRIPTION
Closes #56 

After checking possible side effects, I could only come up with the fact that `relayMessage` - the function used by users to withdraw from L2 to L1 - will change its function signature as its input type will be changed. This will warrant the change in whatever frontend that might be using this function.

This change also brings the solidity typings closer to the [fuel-core typings](https://github.com/FuelLabs/fuel-core/blob/7934cbd05900169a7ed24f78e09fdab04718ec74/crates/types/src/blockchain/header.rs#L91C23-L91C28), as `height` is an `uint32` type in the consensus. I am unsure about the reasoning behind it being `uint64` in solidity, just to truncate it later to `uint32`. Was it originally `u64` in the consensus spec? Maybe @Voxelot can bring some light into it.

EDIT. [So it seems that this is a remnant from a change of spec](https://github.com/FuelLabs/fuel-specs/commit/667429c2d6bd70be6c4a21965728505848eb2be9)