### PR TITLE
Speed up integration tests

### DIFF
--- a/docker/l1-chain/Dockerfile
+++ b/docker/l1-chain/Dockerfile
@@ -1,47 +1,37 @@
 # ====== Build Image ======
 FROM node:16-alpine AS BUILD_IMAGE
 
-# dependencies
-RUN apk --no-cache add git
-RUN npm i -g pnpm
-
-# set workdir
-WORKDIR /l1chain
-
-# clone the contracts repo
-ADD ./packages/solidity-contracts /l1chain/fuel-v2-contracts
-# copy over the fuel chain and replace consts values
-ADD ./docker/l1-chain/.fuelChainConsts.env /l1chain/fuel-v2-contracts/.fuelChainConsts.env
-WORKDIR /l1chain/fuel-v2-contracts
-
-# build the ethereum contracts and environment
-RUN pnpm install
-# replace the fuel chain consts values and change contract code
-RUN pnpm ts-node scripts/replaceFuelChainConsts.ts
-# run contract compile with the new consts
-RUN pnpm run build
-
-# remove build dependencies
-# RUN pnpm prune --prod
-COPY ./docker/l1-chain/hardhat/hardhat.config.ts .
-
-# ====== Final Image ======
-FROM node:16-alpine
-
 ARG L1_IP=0.0.0.0
 ARG L1_PORT=9545
 ARG SERVE_PORT=8081
 
 # dependencies
-RUN apk --no-cache add curl
+RUN apk --no-cache add git curl
 RUN npm i -g pnpm
 
-# set workdir
-WORKDIR /l1chain
-
 # clone the contracts repo
-COPY --from=BUILD_IMAGE /l1chain/fuel-v2-contracts ./fuel-v2-contracts
+ADD ./packages/solidity-contracts/package.json /l1chain/fuel-v2-contracts/
+# copy over the fuel chain and replace consts values
 WORKDIR /l1chain/fuel-v2-contracts
+
+# build the ethereum contracts and environment
+RUN pnpm install
+# replace the fuel chain consts values and change contract code
+ADD ./docker/l1-chain/.fuelChainConsts.env /l1chain/fuel-v2-contracts/.fuelChainConsts.env
+ADD ./packages/solidity-contracts/scripts/replaceFuelChainConsts.ts /l1chain/fuel-v2-contracts/scripts/replaceFuelChainConsts.ts
+ADD ./packages/solidity-contracts/contracts /l1chain/fuel-v2-contracts/contracts
+ADD ./packages/solidity-contracts/scripts /l1chain/fuel-v2-contracts/scripts
+ADD ./packages/solidity-contracts/protocol /l1chain/fuel-v2-contracts/protocol
+RUN pnpm ts-node scripts/replaceFuelChainConsts.ts
+
+
+# remove build dependencies
+# RUN pnpm prune --prod
+COPY ./docker/l1-chain/hardhat/hardhat.config.ts .
+RUN pnpm compile
+
+# Create deployments dir
+RUN mkdir deployments
 
 # expose node and server port
 ENV L1_IP="${L1_IP}"


### PR DESCRIPTION
Make some changes in the dockerfile of l1_chain to speed up testing and make better use of cache

Main gains come from the fact that the download of the solidity compiler and the contracts' compilation itself are done in the building stage instead of the execution stage.