### PR TITLE
Use own fixture for ERC721Gatway tests

### DIFF
--- a/.changeset/healthy-dancers-train.md
+++ b/.changeset/healthy-dancers-train.md
@@ -1,0 +1,5 @@
+---
+'@fuel-bridge/solidity-contracts': patch
+---
+
+Change erc721 tests to use their own fixture and remove some unrelated erc20 tests in them


### PR DESCRIPTION
This is part of efforts to implement the handshake protocol.

The change decouples the unit testing from the integration testing, which are sharing `harness.ts`, and influences in upgrading the contracts with new features.

Additionally removes some lingering erc20 checks, which do not make sense to keep since we are talking about the erc721 context