### PR TITLE
Bump forc

### DIFF
--- a/.changeset/chilled-candles-explain.md
+++ b/.changeset/chilled-candles-explain.md
@@ -1,0 +1,5 @@
+---
+'@fuel-bridge/test-utils': patch
+---
+
+feat: update fuels-ts to 0.71.1

--- a/.changeset/chilled-candles-explain.md
+++ b/.changeset/chilled-candles-explain.md
@@ -1,5 +1,0 @@
----
-'@fuel-bridge/test-utils': patch
----
-
-feat: update fuels-ts to 0.71.1

--- a/.changeset/eleven-ladybugs-explain.md
+++ b/.changeset/eleven-ladybugs-explain.md
@@ -1,0 +1,6 @@
+---
+'@fuel-bridge/message-predicates': minor
+'@fuel-bridge/fungible-token': minor
+---
+
+Update to forc 0.49.1

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -17,7 +17,7 @@ runs:
 
     - name: Init cache
       uses: Swatinem/rust-cache@v2
-    
+
     - name: Install Fuel toolchain
       uses: FuelLabs/action-fuel-toolchain@v0.6.0
       with:

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -3,6 +3,8 @@ name: 'Rust & Forc Setup'
 inputs:
   rust-version:
     default: 1.75.0
+  forc-components:
+    default: 'forc@0.49.1, fuel-core@0.22.0'
 
 runs:
   using: 'composite'
@@ -15,3 +17,9 @@ runs:
 
     - name: Init cache
       uses: Swatinem/rust-cache@v2
+    
+    - name: Install Fuel toolchain
+      uses: FuelLabs/action-fuel-toolchain@v0.6.0
+      with:
+        name: fuel-bridge
+        components: ${{ inputs.forc-components }}

--- a/.github/workflows/pr-release.yaml
+++ b/.github/workflows/pr-release.yaml
@@ -24,7 +24,7 @@ jobs:
           npm-token: ${{ secrets.NPM_TOKEN }}
 
       - name: Build Contracts
-        run: pnpm fuels-forc build
+        run: forc build
 
       - name: Build
         run: pnpm build

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,3 @@ target
 
 # Genearal dist folders
 dist
-
-# fuel toolchain file (not needed as we use from ts-sdk)
-fuel-toolchain.toml

--- a/Forc.lock
+++ b/Forc.lock
@@ -23,7 +23,7 @@ dependencies = [
 
 [[package]]
 name = "core"
-source = "path+from-root-B77DA2F383183718"
+source = "path+from-root-C3992B43B72ADB8C"
 
 [[package]]
 name = "reentrancy"
@@ -37,7 +37,7 @@ dependencies = ["std"]
 
 [[package]]
 name = "std"
-source = "git+https://github.com/fuellabs/sway?tag=v0.48.1#6886ef050ce62afd3fe3186ed562fd33bd76bffa"
+source = "git+https://github.com/fuellabs/sway?tag=v0.49.1#2ac7030570f22510b0ac2a7b5ddf7baa20bdc0e1"
 dependencies = ["core"]
 
 [[package]]

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -9,7 +9,7 @@ This project includes both frontend and contracts. To begin, install dependencie
 - [Docker v20.0.21 or latest stable](https://docs.docker.com/get-docker/)
 - [Docker Compose v2.15.1 or latest stable](https://docs.docker.com/get-docker/)
 - [Rust v1.74.1 or latest `stable`](https://www.rust-lang.org/tools/install)
-- [Forc v0.48.1 with latest toolchain](https://install.fuel.network/latest)
+- [Forc v0.49.1 with latest toolchain](https://install.fuel.network/latest)
 
 ## Running Project Locally
 

--- a/fuel-toolchain.toml
+++ b/fuel-toolchain.toml
@@ -1,0 +1,6 @@
+[toolchain]
+channel = "latest-2023-10-17"
+
+[components]
+forc = "0.49.1"
+fuel-core = "0.22.0"

--- a/packages/esbuild-bin-loader/src/index.ts
+++ b/packages/esbuild-bin-loader/src/index.ts
@@ -1,5 +1,5 @@
-import { hexlify } from 'fuels';
 import { readFileSync } from 'fs';
+import { hexlify } from 'fuels';
 
 export const esbuildBinLoader = {
   name: 'bin-loader',

--- a/packages/fungible-token/README.md
+++ b/packages/fungible-token/README.md
@@ -28,7 +28,7 @@ This project uses the general contract message relaying script/predicate from th
 In the root of the repository run the following command to build all the Sway programs.
 
 ```bash
-pnpm fuels-forc build
+forc build
 ```
 
 ### Running Rust Tests

--- a/packages/fungible-token/README.md
+++ b/packages/fungible-token/README.md
@@ -1,6 +1,6 @@
 <p align="center">
-    <a href="https://crates.io/crates/forc/0.48.1" alt="forc">
-        <img src="https://img.shields.io/badge/forc-v0.48.1-orange" />
+    <a href="https://crates.io/crates/forc/0.49.1" alt="forc">
+        <img src="https://img.shields.io/badge/forc-v0.49.1-orange" />
     </a>
     <a href="https://crates.io/crates/fuel-core/0.22.0" alt="fuel-core">
         <img src="https://img.shields.io/badge/fuel--core-v0.21.0-blue" />

--- a/packages/fungible-token/bridge-fungible-token/src/cast.sw
+++ b/packages/fungible-token/bridge-fungible-token/src/cast.sw
@@ -8,7 +8,9 @@ impl From<b256> for u256 {
     }
 
     fn into(self) -> b256 {
-        let result: b256 = asm(r1: self) { r1: b256 };
+        let result: b256 = asm(r1: self) {
+            r1: b256
+        };
         result
     }
 }

--- a/packages/fungible-token/bridge-fungible-token/src/data_structures.sw
+++ b/packages/fungible-token/bridge-fungible-token/src/data_structures.sw
@@ -38,12 +38,9 @@ impl MessageData {
         };
 
         // TODO: Bug, have to mutate this struct for these values or tests fail
-        msg_data.amount = input_message_data(msg_idx, OFFSET_AMOUNT)
-            .into();
-        msg_data.from = input_message_data(msg_idx, OFFSET_FROM)
-            .into();
-        msg_data.token_id = input_message_data(msg_idx, OFFSET_TOKEN_ID)
-            .into();
+        msg_data.amount = input_message_data(msg_idx, OFFSET_AMOUNT).into();
+        msg_data.from = input_message_data(msg_idx, OFFSET_FROM).into();
+        msg_data.token_id = input_message_data(msg_idx, OFFSET_TOKEN_ID).into();
         let to: b256 = input_message_data(msg_idx, OFFSET_TO).into();
 
         if msg_data.len > ADDRESS_DEPOSIT_DATA_LEN {

--- a/packages/fungible-token/bridge-fungible-token/src/main.sw
+++ b/packages/fungible-token/bridge-fungible-token/src/main.sw
@@ -15,6 +15,11 @@ use events::{ClaimRefundEvent, DepositEvent, RefundRegisteredEvent, WithdrawalEv
 use interface::{bridge::Bridge, src7::{Metadata, SRC7}};
 use reentrancy::reentrancy_guard;
 use std::{
+    asset::{
+        burn,
+        mint,
+        transfer,
+    },
     call_frames::{
         contract_id,
         msg_asset_id,
@@ -30,11 +35,6 @@ use std::{
     inputs::input_message_sender,
     message::send_message,
     string::String,
-    asset::{
-        burn,
-        mint,
-        transfer,
-    },
 };
 use utils::{
     adjust_deposit_decimals,
@@ -49,9 +49,7 @@ configurable {
     BRIDGED_TOKEN_DECIMALS: u8 = 18u8,
     BRIDGED_TOKEN_GATEWAY: b256 = 0x00000000000000000000000096c53cd98B7297564716a8f2E1de2C83928Af2fe,
     BRIDGED_TOKEN: b256 = 0x00000000000000000000000000000000000000000000000000000000deadbeef,
-    NAME: str[64] = __to_str_array(
-        "MY_TOKEN                                                        ",
-    ),
+    NAME: str[64] = __to_str_array("MY_TOKEN                                                        "),
     SYMBOL: str[32] = __to_str_array("MYTKN                           "),
 }
 
@@ -157,8 +155,7 @@ impl MessageReceiver for Contract {
                 // when depositing to a contract, msg_data.len is CONTRACT_DEPOSIT_WITHOUT_DATA_LEN bytes.
                 // If msg_data.len is > CONTRACT_DEPOSIT_WITHOUT_DATA_LEN bytes, 
                 // we must call `process_message()` on the receiving contract, forwarding the newly minted coins with the call.
-                match message_data
-                    .len {
+                match message_data.len {
                     ADDRESS_DEPOSIT_DATA_LEN => {
                         transfer(message_data.to, asset_id, amount);
                     },

--- a/packages/fungible-token/bridge-fungible-token/src/main.sw
+++ b/packages/fungible-token/bridge-fungible-token/src/main.sw
@@ -30,7 +30,7 @@ use std::{
     inputs::input_message_sender,
     message::send_message,
     string::String,
-    token::{
+    asset::{
         burn,
         mint,
         transfer,

--- a/packages/fungible-token/bridge-fungible-token/src/utils.sw
+++ b/packages/fungible-token/bridge-fungible-token/src/utils.sw
@@ -42,7 +42,9 @@ pub fn adjust_withdrawal_decimals(
         value
     };
 
-    let result: b256 = asm(r1: adjusted) { r1: b256 };
+    let result: b256 = asm(r1: adjusted) {
+        r1: b256
+    };
     Result::Ok(result)
 }
 
@@ -71,7 +73,9 @@ pub fn adjust_deposit_decimals(
         value
     };
 
-    let (word1, word2, word3, word4) = asm(r1: adjusted.as_b256()) { r1: (u64, u64, u64, u64) };
+    let (word1, word2, word3, word4) = asm(r1: adjusted.as_b256()) {
+        r1: (u64, u64, u64, u64)
+    };
 
     if word1 == 0 && word2 == 0 && word3 == 0 {
         Result::Ok(word4)
@@ -138,7 +142,9 @@ fn shift_decimals_left(bn: u256, decimals: u8) -> Result<u256, BridgeFungibleTok
 
 fn shift_decimals_right(bn: u256, decimals: u8) -> Result<u256, BridgeFungibleTokenError> {
     let mut bn_clone = bn;
-    let mut decimals_to_shift: u32 = asm(r1: decimals) { r1: u32 };
+    let mut decimals_to_shift: u32 = asm(r1: decimals) {
+        r1: u32
+    };
 
     // the zero case
     if (decimals_to_shift == 0u32) {

--- a/packages/message-predicates/Forc.lock
+++ b/packages/message-predicates/Forc.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "core"
-source = "path+from-root-B77DA2F383183718"
+source = "path+from-root-C3992B43B72ADB8C"
 
 [[package]]
 name = "std"
-source = "git+https://github.com/fuellabs/sway?tag=v0.48.1#6886ef050ce62afd3fe3186ed562fd33bd76bffa"
+source = "git+https://github.com/fuellabs/sway?tag=v0.49.1#2ac7030570f22510b0ac2a7b5ddf7baa20bdc0e1"
 dependencies = ["core"]

--- a/packages/message-predicates/README.md
+++ b/packages/message-predicates/README.md
@@ -19,7 +19,7 @@ The message to contract predicate relies on a script that performs only the foll
 Build:
 
 ```sh
-pnpm fuels-forc build
+pnpm forc build
 cargo run
 ```
 
@@ -34,7 +34,7 @@ cargo test
 Code must be formatted.
 
 ```sh
-pnpm fuels-forc fmt
+pnpm forc fmt
 cargo fmt
 ```
 

--- a/packages/message-predicates/contract-message-predicate/src/contract_message_test.sw
+++ b/packages/message-predicates/contract-message-predicate/src/contract_message_test.sw
@@ -31,7 +31,7 @@ abi VerifyMessageData {
 // TODO: remove once an [into(self) -> u64] is added for the Bytes type
 fn into_u64(b: Bytes) -> u64 {
     asm(ptr: b.buf.ptr, r0) {
-        lw   r0 ptr i0;
+        lw r0 ptr i0;
         r0: u64
     }
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-pnpm fuels-forc build
+forc build
 cargo run
 turbo run build

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-pnpm fuels-forc fmt --check
+pnpm forc fmt --check
 cargo fmt --check
-pnpm fuels-forc build
+pnpm forc build
 cargo clippy --all-features --all-targets -- -D warnings
 pnpm prettier:check

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-pnpm fuels-forc fmt
+pnpm forc fmt
 cargo fmt
 pnpm lint:fix
 pnpm prettier:format

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -24,7 +24,7 @@ pnpm run build
 echo "\n\nCargo test..."
 cargo test
 echo "\n\nForc test..."
-pnpm fuels-forc test
+pnpm forc test
 
 # Start the docker compose file with L1 and Fuel Node
 echo "\n\nStarting docker..."


### PR DESCRIPTION
This PR bumps forc to 0.49.1.

As part of the process the following was also needed:
- Revert back the github actions to use the orignal `forc` binary instead of the one loaded with the `ts-sdk`. This is because otherwise, we are stuck with the forc binary that comes with the sdk, whereas we need to remain mobile
- Apply formatting to appease the new forc rules

