### PR TITLE
Fix Hexens FUEL1-10: use custom error for unknown relay reverts

### DIFF
--- a/.changeset/warm-rings-join.md
+++ b/.changeset/warm-rings-join.md
@@ -1,0 +1,6 @@
+---
+'@fuel-bridge/solidity-contracts': minor
+'@fuel-bridge/fungible-token': minor
+---
+
+Use custom error for relay unknown error reverts

--- a/packages/fungible-token/bridge-fungible-token/src/main.sw
+++ b/packages/fungible-token/bridge-fungible-token/src/main.sw
@@ -357,7 +357,7 @@ fn _process_deposit(message_data: DepositMessage, msg_idx: u64) {
         },
         DepositType::ContractWithData => {
             let dest_contract = abi(MessageReceiver, message_data.to.as_contract_id().unwrap().into());
-            // TODO: Hexens Fuel1-20, if this call fails, funds may get stuck
+            // TODO: Hexens Fuel1-2, if this call fails, funds may get stuck
             dest_contract
                 .process_message {
                     coins: amount,

--- a/packages/solidity-contracts/contracts/fuelchain/FuelMessagePortal/v3/FuelMessagePortalV3.sol
+++ b/packages/solidity-contracts/contracts/fuelchain/FuelMessagePortal/v3/FuelMessagePortalV3.sol
@@ -10,6 +10,7 @@ contract FuelMessagePortalV3 is FuelMessagePortalV2 {
 
     error MessageBlacklisted();
     error WithdrawalsPaused();
+    error MessageRelayFailed();
 
     bool public withdrawalsPaused;
     mapping(bytes32 => bool) public messageIsBlacklisted;
@@ -91,6 +92,52 @@ contract FuelMessagePortalV3 is FuelMessagePortalV2 {
 
         //execute message
         _executeMessage(messageId, message);
+    }
+
+    /// @notice Executes a message in the given header
+    /// @param messageId The id of message to execute
+    /// @param message The message to execute
+    function _executeMessage(bytes32 messageId, Message calldata message) internal virtual override nonReentrant {
+        if (_incomingMessageSuccessful[messageId]) revert AlreadyRelayed();
+
+        //set message sender for receiving contract to reference
+        _incomingMessageSender = message.sender;
+
+        // v2: update accounting if the message carries an amount
+        bool success;
+        bytes memory result;
+        if (message.amount > 0) {
+            uint256 withdrawnAmount = message.amount * PRECISION;
+
+            // Underflow check enabled since the amount is coded in `message`
+            totalDeposited -= withdrawnAmount;
+
+            (success, result) = address(uint160(uint256(message.recipient))).call{value: withdrawnAmount}(message.data);
+        } else {
+            (success, result) = address(uint160(uint256(message.recipient))).call(message.data);
+        }
+
+        if (!success) {
+            // Look for revert reason and bubble it up if present
+            if (result.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+                /// @solidity memory-safe-assembly
+                assembly {
+                    let returndata_size := mload(result)
+                    revert(add(32, result), returndata_size)
+                }
+            }
+            revert MessageRelayFailed();
+        }
+
+        //unset message sender reference
+        _incomingMessageSender = NULL_MESSAGE_SENDER;
+
+        //keep track of successfully relayed messages
+        _incomingMessageSuccessful[messageId] = true;
+
+        //emit event for successful message relay
+        emit MessageRelayed(messageId, message.sender, message.recipient, message.amount);
     }
 
     /**

--- a/packages/solidity-contracts/test/messagesIncomingV3.test.ts
+++ b/packages/solidity-contracts/test/messagesIncomingV3.test.ts
@@ -601,7 +601,7 @@ describe('FuelMessagePortalV3 - Incoming messages', () => {
   describe('Behaves like V1 - Relay both valid and invalid messages', async () => {
     before(async () => {
       const fixt = await fixture();
-      const { V2Implementation } = fixt;
+      const { V3Implementation } = fixt;
       ({
         provider,
         fuelMessagePortal,
@@ -610,7 +610,7 @@ describe('FuelMessagePortalV3 - Incoming messages', () => {
         addresses,
       } = fixt);
 
-      await upgrades.upgradeProxy(fuelMessagePortal, V2Implementation, {
+      await upgrades.upgradeProxy(fuelMessagePortal, V3Implementation, {
         unsafeAllow: ['constructor'],
         constructorArgs: [MaxUint256],
       });
@@ -876,7 +876,7 @@ describe('FuelMessagePortalV3 - Incoming messages', () => {
           blockInRoot,
           msgInBlock
         )
-      ).to.be.revertedWith('Message relay failed');
+      ).to.be.revertedWithCustomError(fuelMessagePortal, 'MessageRelayFailed');
       expect(
         await fuelMessagePortal.incomingMessageSuccessful(msgID)
       ).to.be.equal(false);
@@ -901,7 +901,7 @@ describe('FuelMessagePortalV3 - Incoming messages', () => {
           blockInRoot,
           msgInBlock
         )
-      ).to.be.revertedWith('Message relay failed');
+      ).to.be.revertedWithCustomError(fuelMessagePortal, 'MessageRelayFailed');
       expect(
         await fuelMessagePortal.incomingMessageSuccessful(msgID)
       ).to.be.equal(false);


### PR DESCRIPTION
This PR changes FuelMessagePortal 's revert on relay (`revert("Message relay failed")`) to a custom error to achieve some gas savings