### PR TITLE
feat: remove @fuel-contracts/merkle-sol and port VerifyBinaryTree

### DIFF
--- a/.changeset/metal-glasses-rest.md
+++ b/.changeset/metal-glasses-rest.md
@@ -1,0 +1,5 @@
+---
+'@fuel-bridge/solidity-contracts': minor
+---
+
+Ported @fuel-contracts/merkle-sol utils

--- a/packages/solidity-contracts/contracts/fuelchain/FuelMessagePortal.sol
+++ b/packages/solidity-contracts/contracts/fuelchain/FuelMessagePortal.sol
@@ -6,7 +6,7 @@ import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/U
 import {AccessControlUpgradeable} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 import {ReentrancyGuardUpgradeable} from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
-import {verifyBinaryTree} from "@fuel-contracts/merkle-sol/contracts/tree/binary/BinaryMerkleTree.sol";
+import {verifyBinaryTree} from "../lib/VerifyBinaryTree/VerifyBinaryTree.sol";
 import {FuelChainState} from "./FuelChainState.sol";
 import {FuelBlockHeader, FuelBlockHeaderLib} from "./types/FuelBlockHeader.sol";
 import {FuelBlockHeaderLite, FuelBlockHeaderLiteLib} from "./types/FuelBlockHeaderLite.sol";

--- a/packages/solidity-contracts/contracts/lib/VerifyBinaryTree/Constants.sol
+++ b/packages/solidity-contracts/contracts/lib/VerifyBinaryTree/Constants.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.4;
+
+library Constants {
+    ///////////////
+    // Constants //
+    ///////////////
+
+    /// @dev Maximum tree height
+    uint256 internal constant MAX_HEIGHT = 256;
+
+    /// @dev Empty node hash
+    bytes32 internal constant EMPTY = sha256("");
+
+    /// @dev Default value for sparse Merkle tree node
+    bytes32 internal constant ZERO = bytes32(0);
+
+    /// @dev The null pointer
+    bytes32 internal constant NULL = bytes32(0);
+
+    /// @dev The prefixes of leaves and nodes
+    bytes1 internal constant LEAF_PREFIX = 0x00;
+    bytes1 internal constant NODE_PREFIX = 0x01;
+}

--- a/packages/solidity-contracts/contracts/lib/VerifyBinaryTree/Node.sol
+++ b/packages/solidity-contracts/contracts/lib/VerifyBinaryTree/Node.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.4;
+
+/// @notice Merkle Tree Node structure.
+struct Node {
+    bytes32 digest;
+    // Left child.
+    bytes32 leftChildPtr;
+    // Right child.
+    bytes32 rightChildPtr;
+}

--- a/packages/solidity-contracts/contracts/lib/VerifyBinaryTree/TreeHasher.sol
+++ b/packages/solidity-contracts/contracts/lib/VerifyBinaryTree/TreeHasher.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.4;
+
+import {CryptographyLib} from "../Cryptography.sol";
+import {Constants} from "./Constants.sol";
+import {Node} from "./Node.sol";
+
+/// @notice hash some data
+/// @param data: The data to be hashed
+// solhint-disable-next-line func-visibility
+function hash(bytes memory data) pure returns (bytes32) {
+    return CryptographyLib.hash(data);
+}
+
+/// @notice Calculate the digest of a node
+/// @param left : The left child
+/// @param right: The right child
+/// @return digest : The node digest
+// solhint-disable-next-line func-visibility
+function nodeDigest(bytes32 left, bytes32 right) pure returns (bytes32 digest) {
+    digest = hash(abi.encodePacked(Constants.NODE_PREFIX, left, right));
+}
+
+/// @notice Calculate the digest of a leaf
+/// @param data : The data of the leaf
+/// @return digest : The leaf digest
+// solhint-disable-next-line func-visibility
+function leafDigest(bytes memory data) pure returns (bytes32 digest) {
+    digest = hash(abi.encodePacked(Constants.LEAF_PREFIX, data));
+}

--- a/packages/solidity-contracts/contracts/lib/VerifyBinaryTree/Utils.sol
+++ b/packages/solidity-contracts/contracts/lib/VerifyBinaryTree/Utils.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.4;
+
+import {Constants} from "./Constants.sol";
+
+/// @notice Calculate the starting bit of the path to a leaf
+/// @param numLeaves : The total number of leaves in the tree
+/// @return startingBit : The starting bit of the path
+// solhint-disable-next-line func-visibility
+function getStartingBit(uint256 numLeaves) pure returns (uint256 startingBit) {
+    // Determine height of the left subtree. This is the maximum path length, so all paths start at this offset from the right-most bit
+    startingBit = 0;
+    while ((1 << startingBit) < numLeaves) {
+        startingBit += 1;
+    }
+    return Constants.MAX_HEIGHT - startingBit;
+}
+
+/// @notice Calculate the length of the path to a leaf
+/// @param key: The key of the leaf
+/// @param numLeaves: The total number of leaves in the tree
+/// @return pathLength : The length of the path to the leaf
+/// @dev A precondition to this function is that `numLeaves > 1`, so that `(pathLength - 1)` does not cause an underflow when pathLength = 0.
+// solhint-disable-next-line func-visibility
+function pathLengthFromKey(uint256 key, uint256 numLeaves) pure returns (uint256 pathLength) {
+    // Get the height of the left subtree. This is equal to the offset of the starting bit of the path
+    pathLength = 256 - getStartingBit(numLeaves);
+
+    // Determine the number of leaves in the left subtree
+    uint256 numLeavesLeftSubTree = (1 << (pathLength - 1));
+
+    // If leaf is in left subtree, path length is full height of left subtree
+    if (key <= numLeavesLeftSubTree - 1) {
+        return pathLength;
+    }
+    // Otherwise, if left sub tree has only one leaf, path has one additional step
+    else if (numLeavesLeftSubTree == 1) {
+        return 1;
+    }
+    // Otherwise, if right sub tree has only one leaf, path has one additional step
+    else if (numLeaves - numLeavesLeftSubTree <= 1) {
+        return 1;
+    }
+    // Otherwise, add 1 to height and recurse into right subtree
+    else {
+        return 1 + pathLengthFromKey(key - numLeavesLeftSubTree, numLeaves - numLeavesLeftSubTree);
+    }
+}

--- a/packages/solidity-contracts/contracts/lib/VerifyBinaryTree/VerifyBinaryTree.sol
+++ b/packages/solidity-contracts/contracts/lib/VerifyBinaryTree/VerifyBinaryTree.sol
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+/// @title VerifyBinaryTree
+/// @author Fuel Labs
+/// @dev This implements verification for the binary trees used by the FuelVM
+/// @dev For more details, check:
+/// @dev https://github.com/FuelLabs/fuel-specs/blob/master/src/protocol/cryptographic-primitives.md
+
+pragma solidity ^0.8.4;
+
+import {Node} from "./Node.sol";
+import {nodeDigest, leafDigest} from "./TreeHasher.sol";
+import {pathLengthFromKey, getStartingBit} from "./Utils.sol";
+
+/// @notice Verify if element (key, data) exists in Merkle tree, given data, proof, and root.
+/// @param root: The root of the tree in which verify the given leaf
+/// @param data: The data of the leaf to verify
+/// @param key: The key of the leaf to verify.
+/// @param proof: Binary Merkle Proof for the leaf.
+/// @param numLeaves: The number of leaves in the tree
+/// @return : Whether the proof is valid
+/// @dev numLeaves is necessary to determine height of sub-tree containing the data to prove
+// solhint-disable-next-line func-visibility
+function verifyBinaryTree(
+    bytes32 root,
+    bytes memory data,
+    bytes32[] memory proof,
+    uint256 key,
+    uint256 numLeaves
+) pure returns (bool) {
+    // A sibling at height 1 is created by getting the hash of the data to prove.
+    return verifyBinaryTreeDigest(root, leafDigest(data), proof, key, numLeaves);
+}
+
+/// @notice Verify if element (key, digest) exists in Merkle tree, given digest, proof, and root.
+/// @param root: The root of the tree in which verify the given leaf
+/// @param digest: The digest of the data of the leaf to verify
+/// @param key: The key of the leaf to verify.
+/// @param proof: Binary Merkle Proof for the leaf.
+/// @param numLeaves: The number of leaves in the tree
+/// @return : Whether the proof is valid
+/// @dev numLeaves is necessary to determine height of sub-tree containing the data to prove
+// solhint-disable-next-line func-visibility
+function verifyBinaryTreeDigest(
+    bytes32 root,
+    bytes32 digest,
+    bytes32[] memory proof,
+    uint256 key,
+    uint256 numLeaves
+) pure returns (bool) {
+    // Check proof is correct length for the key it is proving
+    if (numLeaves <= 1) {
+        if (proof.length != 0) {
+            return false;
+        }
+    } else if (proof.length != pathLengthFromKey(key, numLeaves)) {
+        return false;
+    }
+
+    // Check key is in tree
+    if (key >= numLeaves) {
+        return false;
+    }
+
+    // Null proof is only valid if numLeaves = 1
+    // If so, just verify digest is root
+    if (proof.length == 0) {
+        if (numLeaves == 1) {
+            return (root == digest);
+        } else {
+            return false;
+        }
+    }
+
+    uint256 height = 1;
+    uint256 stableEnd = key;
+
+    // While the current subtree (of height 'height') is complete, determine
+    // the position of the next sibling using the complete subtree algorithm.
+    // 'stableEnd' tells us the ending index of the last full subtree. It gets
+    // initialized to 'key' because the first full subtree was the
+    // subtree of height 1, created above (and had an ending index of
+    // 'key').
+
+    while (true) {
+        // Determine if the subtree is complete. This is accomplished by
+        // rounding down the key to the nearest 1 << 'height', adding 1
+        // << 'height', and comparing the result to the number of leaves in the
+        // Merkle tree.
+
+        uint256 subTreeStartIndex = (key / (1 << height)) * (1 << height);
+        uint256 subTreeEndIndex = subTreeStartIndex + (1 << height) - 1;
+
+        // If the Merkle tree does not have a leaf at index
+        // 'subTreeEndIndex', then the subtree of the current height is not
+        // a complete subtree.
+        if (subTreeEndIndex >= numLeaves) {
+            break;
+        }
+        stableEnd = subTreeEndIndex;
+
+        // Determine if the key is in the first or the second half of
+        // the subtree.
+        if (proof.length <= height - 1) {
+            return false;
+        }
+        if (key - subTreeStartIndex < (1 << (height - 1))) {
+            digest = nodeDigest(digest, proof[height - 1]);
+        } else {
+            digest = nodeDigest(proof[height - 1], digest);
+        }
+
+        height += 1;
+    }
+
+    // Determine if the next hash belongs to an orphan that was elevated. This
+    // is the case IFF 'stableEnd' (the last index of the largest full subtree)
+    // is equal to the number of leaves in the Merkle tree.
+    if (stableEnd != numLeaves - 1) {
+        if (proof.length <= height - 1) {
+            return false;
+        }
+        digest = nodeDigest(digest, proof[height - 1]);
+        height += 1;
+    }
+
+    // All remaining elements in the proof set will belong to a left sibling\
+    // i.e proof sideNodes are hashed in "from the left"
+    while (height - 1 < proof.length) {
+        digest = nodeDigest(proof[height - 1], digest);
+        height += 1;
+    }
+
+    return (digest == root);
+}

--- a/packages/solidity-contracts/package.json
+++ b/packages/solidity-contracts/package.json
@@ -37,7 +37,6 @@
     "lint": "prettier --list-different --plugin=prettier-plugin-solidity 'contracts/**/*.sol'"
   },
   "devDependencies": {
-    "@fuel-contracts/merkle-sol": "^0.1.4",
     "@fuel-ts/merkle": "^0.21.2",
     "@nomicfoundation/hardhat-chai-matchers": "^2.0.4",
     "@nomicfoundation/hardhat-ethers": "^3.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,9 +114,6 @@ importers:
 
   packages/solidity-contracts:
     devDependencies:
-      '@fuel-contracts/merkle-sol':
-        specifier: ^0.1.4
-        version: 0.1.4
       '@fuel-ts/merkle':
         specifier: ^0.21.2
         version: 0.21.2
@@ -813,9 +810,6 @@ packages:
   '@fastify/busboy@2.1.1':
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
-
-  '@fuel-contracts/merkle-sol@0.1.4':
-    resolution: {integrity: sha512-r2jLlVPb/n3vALQ1EissdiW96kPcAGg4Yu/hsGHe+ZEgu8kEYSLWqPAV0shU72q//Ofxfh7xznmUMf7lkzNLRQ==}
 
   '@fuel-ts/abi-coder@0.85.0':
     resolution: {integrity: sha512-BQsjtD2aGDQir4twaCqqPH7oIjg0/mX59FCf/hT5rXRhwBXTPi60vSXniNyQUGuMRYcmRMvr+6GAEmD6w9kFXw==}
@@ -3002,15 +2996,6 @@ packages:
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
-  ganache-cli@6.12.2:
-    resolution: {integrity: sha512-bnmwnJDBDsOWBUP8E/BExWf85TsdDEFelQSzihSJm9VChVO1SHp94YXLP5BlA4j/OTxp0wR4R1Tje9OHOuAJVw==}
-    deprecated: ganache-cli is now ganache; visit https://trfl.io/g7 for details
-    hasBin: true
-    bundledDependencies:
-      - source-map-support
-      - yargs
-      - ethereumjs-util
-
   ganache@7.4.3:
     resolution: {integrity: sha512-RpEDUiCkqbouyE7+NMXG26ynZ+7sGiODU84Kz+FVoXUnQ4qQM4M8wif3Y4qUCt+D/eM1RVeGq0my62FPD6Y1KA==}
     hasBin: true
@@ -4562,6 +4547,7 @@ packages:
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   ripemd160@2.0.2:
@@ -6274,11 +6260,6 @@ snapshots:
       '@ethersproject/strings': 5.7.0
 
   '@fastify/busboy@2.1.1': {}
-
-  '@fuel-contracts/merkle-sol@0.1.4':
-    dependencies:
-      ganache-cli: 6.12.2
-      mocha: 10.4.0
 
   '@fuel-ts/abi-coder@0.85.0(bufferutil@4.0.5)(utf-8-validate@5.0.7)':
     dependencies:
@@ -9245,8 +9226,6 @@ snapshots:
   functional-red-black-tree@1.0.1: {}
 
   functions-have-names@1.2.3: {}
-
-  ganache-cli@6.12.2: {}
 
   ganache@7.4.3:
     optionalDependencies:


### PR DESCRIPTION
Closes #181 

Port and prune the utility `verifyBinaryTree` from [@fuel-contracts/merkle-sol ](https://github.com/FuelLabs/fuel-merkle-sol) which is about to be archived and deprecated.