### PR TITLE
chore(docs):Fix typos in  ARCHITECTURE.md

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,11 +16,11 @@ Before delving into the details, let's understand a few key concepts that will b
 - Fuel sequencers: Entities that process L2 transactions and keep the ledger updated.
 - L1 Commits: Transactions on the L1 that start the finalization process of a Fuel epoch.
 - Finality: State of commits by which the commit cannot be changed, it is considered honest and immutable - final. When an epoch is committed, a clock starts. If the commit is correct, time will pass and the epoch will be final - it cannot be reverted or changed. If the commit is not correct, an honest party can challenge it.
-- Block comitter: entity responsible for listening to finished epochs from the Fuel Blockchain and comitting these epochs to the `FuelChainState` contract.
+- Block committer: entity responsible for listening to finished epochs from the Fuel Blockchain and committing these epochs to the `FuelChainState` contract.
 - `FuelChainState` contract: L1 Smart contract that holds epoch information.
 - `FuelMessagePortal` contract: L1 Smart contract that is able to validate relay messages from Fuel Blocks that have been committed to the state contract, and relays those messages to the corresponding entities in L1
 - Layer 1 Bridge smart contract: L1 smart contract that holds L1 tokens. Upon user deposits, it generates an message for the L2 counterpart to mint the associated L2 token.
-- Layer 2 Bridge smart contract: L2 (Fuel) smart contract that mints L2 tokens when receiving messsages from the L1 counterpart. Similarly, burns L2 tokens and generates a withdrawal message for the L1 contract to release L1 tokens to their rightful owner.
+- Layer 2 Bridge smart contract: L2 (Fuel) smart contract that mints L2 tokens when receiving messages from the L1 counterpart. Similarly, burns L2 tokens and generates a withdrawal message for the L1 contract to release L1 tokens to their rightful owner.
 - Deposit: User action by which some L1 tokens are locked in the L1 bridge smart contracts, minting the same amount in the L2 chain.
 - Withdrawal: User action by which some L2 tokens are burnt in the L2 bridge smart contracts, releasing the burnt amount in the L1 chain.
 
@@ -47,7 +47,7 @@ The [Message Portal](../packages/solidity-contracts/contracts/fuelchain/FuelMess
 
 #### L1 Deposit
 
-A deposit operation is an example of message passing from L1 entities to L2 entities. The user will send a transaction to deposit an asset in a L1 bridge contract, which will in turn emit a message through the `FuelMessagePortal` to be picked up by the Fuel blockchain 's sequencer. Sequencers will include this deposit message as part of an UTXO that can be spent by any entity, but forcing the condition of being delivered to the L2 bridge contract. Once the UTXO is "spent" (delivered), this last contract will have the capability of processing these messages, validating that their sender is the L1 bridge contract, and then proceeding to mint an equivalent asset and amount in the Fuel blockchain to the one originally depositted in the L1. Then, the minted assets become available to the user in the L2.
+A deposit operation is an example of message passing from L1 entities to L2 entities. The user will send a transaction to deposit an asset in a L1 bridge contract, which will in turn emit a message through the `FuelMessagePortal` to be picked up by the Fuel blockchain 's sequencer. Sequencers will include this deposit message as part of an UTXO that can be spent by any entity, but forcing the condition of being delivered to the L2 bridge contract. Once the UTXO is "spent" (delivered), this last contract will have the capability of processing these messages, validating that their sender is the L1 bridge contract, and then proceeding to mint an equivalent asset and amount in the Fuel blockchain to the one originally deposited in the L1. Then, the minted assets become available to the user in the L2.
 
 TODO update this diagram
 ![L1 Deposit](l1_deposit.png)
@@ -64,7 +64,7 @@ The mechanism that implements messaging from L2 to L1 can be more convoluted; be
 
 Any user on the L2 can trigger transactions that generate a message. This message is included as part of the Fuel block, and its inclusion can be proven by verifying a `Merkle root` in the block header that commits to a `Merkle tree` containing the message. The block hash is derived, among other fields, from this root.
 
-Fuel blocks are packed and committed together by the mechanism described two sections above, `block comitting`. A Fuel epoch will be committed at the [Chain State contract](../packages/solidity-contracts/contracts/fuelchain/FuelChainState.sol) with the last block of the epoch, namely the `Fuel root block`. This block features another `Merkle root` that commits to a tree consisting of the block hashes of the epoch. Again, the hash of this root block is derived, among other elements, from this root.
+Fuel blocks are packed and committed together by the mechanism described two sections above, `block committing`. A Fuel epoch will be committed at the [Chain State contract](../packages/solidity-contracts/contracts/fuelchain/FuelChainState.sol) with the last block of the epoch, namely the `Fuel root block`. This block features another `Merkle root` that commits to a tree consisting of the block hashes of the epoch. Again, the hash of this root block is derived, among other elements, from this root.
 
 Once the committed epoch has finalized, an user in the L1 blockchain can prove that the original message was included in the finalized epoch:
 
@@ -97,6 +97,6 @@ You can follow the implementation of this flow via:
 
 ## Decimals adjustment
 
-Easing the operation and participation of light clients in the network without compromising on security is a key principle in Fuel. In that sense, Fuel strives to minimize the size of the information that is exchanged between peers through the protocol. One of the design decisions furthering that goal is the use of 64 bits (`u64`) to code the balances that are bridged from L1 to L2. The most popular token standard, `ERC20`, codes the amounts with `256 bits`. If the amount transferred from L1 to L2 surpasses the capacity of Fuel to mint the L2 counterpart, a `refund` message will be generated, that will allow the user to retrieve the originally depositted amount in L1.
+Easing the operation and participation of light clients in the network without compromising on security is a key principle in Fuel. In that sense, Fuel strives to minimize the size of the information that is exchanged between peers through the protocol. One of the design decisions furthering that goal is the use of 64 bits (`u64`) to code the balances that are bridged from L1 to L2. The most popular token standard, `ERC20`, codes the amounts with `256 bits`. If the amount transferred from L1 to L2 surpasses the capacity of Fuel to mint the L2 counterpart, a `refund` message will be generated, that will allow the user to retrieve the originally deposited amount in L1.
 
 Additionally, it is a de-facto practice in the space to use 18 decimals to represent the token, whereas in Fuel, 9 decimals are used to represent amounts under the unit. This means that there is a potential loss of precision when it comes to translating L1 amounts to L2 amounts, as the user could lose some dust amounts between bridging operations. Ideally, this limitation could be worked around as long as the deposits initiated in L1 do not specify amounts greater than 9 decimals (i.e. 1.0000000010 does not lose amounts, 1.0000000011 would lose 0.0000000001). DApps that enable bridge operations should observe this limitation and truncate the amounts to avoid loss of precision.


### PR DESCRIPTION
This PR corrects several spelling mistakes in the documentation to improve clarity and readability. Below are the corrections made:

- `messsages` corrected to `messages`
- `comitting` corrected to `committing`
- `depositted` corrected to `deposited`
- `comitter` corrected to `committer`

No functional changes were made; these are purely text corrections.