### PR TITLE
Change FTI min gas to 10_000

### DIFF
--- a/packages/solidity-contracts/deploy/hardhat/002.fuel_message_portal_v4.ts
+++ b/packages/solidity-contracts/deploy/hardhat/002.fuel_message_portal_v4.ts
@@ -7,7 +7,7 @@ import { FuelMessagePortalV4__factory as FuelMessagePortal } from '../../typecha
 const ETH_DEPOSIT_LIMIT = MaxUint256;
 const FTI_GAS_LIMIT = 2n ** 64n - 1n;
 const FTI_MIN_GAS_PRICE = parseUnits('1', 'gwei');
-const FTI_MIN_GAS_PER_TX = 1;
+const FTI_MIN_GAS_PER_TX = 10_000;
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const {


### PR DESCRIPTION
Mentioned in https://github.com/FuelLabs/fuel-core/issues/2114

> Maybe increase the minimal gas on the L1 side to be more than 1 https://github.com/FuelLabs/fuel-bridge/pull/215/files#diff-cf9b39d4822d2f60928e44960317ad86812ccf644704cfdd364279ba02e673acR10. Maybe 10_000 is not bad as a default value.